### PR TITLE
Update docker-compose.yml, added container names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   webhook:
+    container_name: "webhook-site"
     image: "webhooksite/webhook.site"
     # Enable build for development:
     # build:
@@ -23,9 +24,11 @@ services:
       - redis
 
   redis:
+    container_name: "webhook-redis"
     image: "redis:alpine"
 
   laravel-echo-server:
+    container_name: "laravel-echo-server"
     image: "webhooksite/laravel-echo-server"
     environment:
       - LARAVEL_ECHO_SERVER_AUTH_HOST=http://webhook


### PR DESCRIPTION
This pull request includes changes to the `docker-compose.yml` file to specify container names for various services. This helps in identifying and managing the containers more easily and fixes the broken socket.io connection issue #165 

Changes to `docker-compose.yml`:

* Added `container_name: "webhook-site"` for the `webhook` service.
* Added `container_name: "webhook-redis"` for the `redis` service.
* Added `container_name: "laravel-echo-server"` for the `laravel-echo-server` service.